### PR TITLE
Keep username

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,10 @@
             return queryParams;
         }
 
-        var site = getURLParams(window.location.search).site || "";
-        var username = getURLParams(window.location.search).username || "";
+        var urlParams = getURLParams(window.location.search);
+        var site = urlParams.site || "";
+        var username = urlParams.username || "";
+        var access_token = urlParams.access_token || "";
     </script>
     <!-- BEGIN LivePerson Monitor. -->
     <script type="text/javascript">

--- a/script.js
+++ b/script.js
@@ -15,48 +15,55 @@ if (site && username && access_token) {
         callback(access_token, window.location.href);
     };
 }
-else {
+else if (site && username) {
+    ajaxLogin(site, username);
+} else {
     $("#lp_form").submit(function (e) {
         e.preventDefault();
         var url = "https://exampleauth.cloud.lprnd.net:1980";
         var site = $("#lp_account").val();
         var username = $("#lp_username").val();
-        var href;
+	ajaxLogin(site, username);
+    });
+}
 
-        $.ajax({
-            url: 'https://barakauth.auth0.com/oauth/token',
-            contentType: 'application/json',
-			type: 'POST',
-			processData: false,
-            data: JSON.stringify({
-                client_id: 'BscG0X3K6R8dgFZf90ydTUOETQztDvrq',
-	    		client_secret: 'u1qHTi_DQ7GVy-Z_9jI7wknEppVpvKYFZ7nTf_JrXlaRDVRorEz3xni5mG_4v7k0',
-	    		audience: 'https://barakauth.auth0.com/api/v2/',
-	    		grant_type: 'client_credentials'
-            }),
-            error: function (XMLHttpRequest, textStatus, errorThrown) {
-                console.error('Failed to generate JWT', textStatus, errorThrown);
-            },
-            success: function (data) {
-                href = updateQueryStringParameter(window.location.href, "site", site);
-                href = updateQueryStringParameter(href, "username", username);
-                href = updateQueryStringParameter(href, "access_token", (data && data.access_token));
-                window.location.href = href;
-            }
-        });
+function ajaxLogin(site, username) {
+    var href;
 
-        function updateQueryStringParameter(uri, key, value) {
-            var re = new RegExp("([?&])" + key + "=.*?(&|$)", "i");
-            var separator = uri.indexOf('?') !== -1 ? "&" : "?";
-            if (uri.match(re)) {
-                return uri.replace(re, '$1' + key + "=" + value + '$2');
-            }
-            else {
-                return uri + separator + key + "=" + value;
-            }
+    $.ajax({
+        url: 'https://barakauth.auth0.com/oauth/token',
+        contentType: 'application/json',
+        type: 'POST',
+        processData: false,
+        data: JSON.stringify({
+            client_id: 'BscG0X3K6R8dgFZf90ydTUOETQztDvrq',
+            client_secret: 'u1qHTi_DQ7GVy-Z_9jI7wknEppVpvKYFZ7nTf_JrXlaRDVRorEz3xni5mG_4v7k0',
+            audience: 'https://barakauth.auth0.com/api/v2/',
+            grant_type: 'client_credentials'
+        }),
+        error: function (XMLHttpRequest, textStatus, errorThrown) {
+            console.error('Failed to generate JWT', textStatus, errorThrown);
+        },
+        success: function (data) {
+            href = updateQueryStringParameter(window.location.href, "site", site);
+            href = updateQueryStringParameter(href, "username", username);
+            href = updateQueryStringParameter(href, "access_token", (data && data.access_token));
+            window.location.href = href;
         }
     });
 }
+
+function updateQueryStringParameter(uri, key, value) {
+    var re = new RegExp("([?&])" + key + "=.*?(&|$)", "i");
+    var separator = uri.indexOf('?') !== -1 ? "&" : "?";
+    if (uri.match(re)) {
+	return uri.replace(re, '$1' + key + "=" + value + '$2');
+    }
+    else {
+	return uri + separator + key + "=" + value;
+    }
+}
+
 
 $('#lp_lnk_setup').click(function () {
     var isDescriptionDisplay = $('#lp_account_setup_description').css('display') === 'block';

--- a/script.js
+++ b/script.js
@@ -3,7 +3,7 @@ if (site) {
     $("#lp_account").val(site);
 }
 
-if (site && username) {
+if (site && username && access_token) {
     $("#lp_username").attr("disabled", "disabled");
     $("#lp_username").val(username);
 
@@ -12,7 +12,7 @@ if (site && username) {
     lpTag.sdes.push({"type": "ctmrinfo", "info": {customerId: "lpTest" + username}});
 
     window.LPJsMethodName = function (callback) {
-        callback(username, window.location.href);
+        callback(access_token, window.location.href);
     };
 }
 else {
@@ -39,7 +39,9 @@ else {
             },
             success: function (data) {
                 href = updateQueryStringParameter(window.location.href, "site", site);
-                window.location.href = updateQueryStringParameter(href, "username", (data && data.access_token) || username);
+                href = updateQueryStringParameter(href, "username", username);
+                href = updateQueryStringParameter(href, "access_token", (data && data.access_token));
+                window.location.href = href;
             }
         });
 

--- a/script.js
+++ b/script.js
@@ -3,21 +3,23 @@ if (site) {
     $("#lp_account").val(site);
 }
 
-if (site && username && access_token) {
+if (site && username) {
     $("#lp_username").attr("disabled", "disabled");
     $("#lp_username").val(username);
 
     $("#lp_btn_login").hide();
 
-    lpTag.sdes.push({"type": "ctmrinfo", "info": {customerId: "lpTest" + username}});
+    if (access_token) {
+        lpTag.sdes.push({"type": "ctmrinfo", "info": {customerId: "lpTest" + username}});
 
-    window.LPJsMethodName = function (callback) {
-        callback(access_token, window.location.href);
-    };
+        window.LPJsMethodName = function (callback) {
+            callback(access_token, window.location.href);
+        };
+    } else {
+        ajaxLogin(site, username);
+    }
 }
-else if (site && username) {
-    ajaxLogin(site, username);
-} else {
+else {
     $("#lp_form").submit(function (e) {
         e.preventDefault();
         var url = "https://exampleauth.cloud.lprnd.net:1980";


### PR DESCRIPTION
- Create access_token query param instead of relying on username.
- Pass the username in the SDE, and the access_token in the authentication.